### PR TITLE
chore(deps): bump snakecase-keys to ^8.1.0, regenerate SDK 2.0.33

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.761.9
   generationVersion: 2.881.4
-  releaseVersion: 2.0.32
-  configChecksum: 6858266f8eed957f86d57e2fa5eb11e6
+  releaseVersion: 2.0.33
+  configChecksum: b70324b550aed3cec7e0688045edb669
   repoURL: https://github.com/gr4vy/gr4vy-typescript.git
   installationURL: https://github.com/gr4vy/gr4vy-typescript
   published: true
 persistentEdits:
-  generation_id: a63a8e6a-3e2c-48b7-bcac-3261c0726034
-  pristine_commit_hash: 507cac4c34b9c689cfe6d8c211684283415f0040
-  pristine_tree_hash: c5a54c5244ab3ade038a0377694df394e50ef94c
+  generation_id: f628f418-2718-4419-be95-b7c291803b3f
+  pristine_commit_hash: 9d8dcd44c06474b7f62421d98e16d2c54804dd6f
+  pristine_tree_hash: cba38560c6fd0348a05a774856e3581322a862a9
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -2463,12 +2463,12 @@ trackedFiles:
     pristine_git_object: 6e10529a93fb4185b404d0e45a9ce98b7b0ae408
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:76f36d4887833e28d5f8d2df6871c5ffa0ea1b19
-    pristine_git_object: a46bfeed3d6f2dcfab449207320743964775c6de
+    last_write_checksum: sha1:11f8802d7d1a0a5ac659152bf117cd25b1ab66d8
+    pristine_git_object: 07c04310c14f3993e5beb08469da8feb4aeea779
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:90f29a2a7fd66a751eecd2391e12bb12d6b07a6a
-    pristine_git_object: bc835a9cac6414ef48ef493fdc6046874c98fb4a
+    last_write_checksum: sha1:a809af5871a47597dff0b6d880e07e84a1ced737
+    pristine_git_object: 079639b696456f7ea77536395cb5b2affc52f4ae
   src/core.ts:
     id: f431fdbcd144
     last_write_checksum: sha1:45271ffd8867c65f66117c59ce98a8b3d8045841
@@ -2903,8 +2903,8 @@ trackedFiles:
     pristine_git_object: 0aebd8b0a4867e35cb3348fc52921c3c0b4725b7
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:2c263fc87682d80a67215c381308fc77e70d7ebb
-    pristine_git_object: 93cb9fc1d80d233dd17d5bfc9cbf238c060fe430
+    last_write_checksum: sha1:738727259fda55d5e41da41b4b5c17f1066813da
+    pristine_git_object: 9c696a502cb7d2864a4d98a0ffaaf3925615197c
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:1dd3e3fbb4550c4bf31f5ef997faff355d6f3250

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -29,12 +29,12 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 typescript:
-  version: 2.0.32
+  version: 2.0.33
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies:
       jsonwebtoken: ^9.0.3
-      snakecase-keys: ^6.0.0
+      snakecase-keys: ^8.1.0
     devDependencies:
       '@types/jsonwebtoken': ^9.0.10
       timekeeper: ^2.3.1

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -19,7 +19,7 @@ targets:
         sourceRevisionDigest: sha256:be19086072e540948face07e56ccc807d0b1b348ef327e63a5341335b801bedd
         sourceBlobDigest: sha256:3e55b309f33d539f04010331b2bdc7132e794dec95f8a9f559f7bca8dfbe2cfd
         codeSamplesNamespace: openapi-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:e2265590d08f7029dcb010e9d6e7d3fc89e1eb0c68f134370e642a3302dba0df
+        codeSamplesRevisionDigest: sha256:9f60084e42aaea0cd4d2591121788eb2647bccbc7cd4316e2748aabc6f7f45e2
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -18,10 +18,10 @@
     },
     "..": {
       "name": "@gr4vy/sdk",
-      "version": "2.0.32",
+      "version": "2.0.33",
       "dependencies": {
         "jsonwebtoken": "^9.0.3",
-        "snakecase-keys": "^6.0.0",
+        "snakecase-keys": "^8.1.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "devDependencies": {

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@gr4vy/sdk",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@gr4vy/sdk",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gr4vy/sdk",
-      "version": "2.0.32",
+      "version": "2.0.33",
       "dependencies": {
         "jsonwebtoken": "^9.0.3",
-        "snakecase-keys": "^6.0.0",
+        "snakecase-keys": "^8.1.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "devDependencies": {
@@ -2460,14 +2460,14 @@
       }
     },
     "node_modules/snakecase-keys": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-6.0.0.tgz",
-      "integrity": "sha512-E5a0C3rcj+Cvq+dt41mw6tV6Wx78/JpQyR71GDiyGSXdp3jEvKxv8pIP0tOHmEMiqKVZSwflXtlWwqNn5oTbbQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-8.1.0.tgz",
+      "integrity": "sha512-9/Eug2btrCiOi+9+vIXJnxUcKVfcbLy5Uwff4BrO6PQf3Oq/2iYQ/1zkmnrpIIjfel/DAasAlux7OvAmCa+Xnw==",
       "license": "MIT",
       "dependencies": {
-        "map-obj": "^4.1.0",
+        "map-obj": "^4.2.0",
         "snake-case": "^3.0.4",
-        "type-fest": "^3.12.0"
+        "type-fest": "^4.15.0"
       },
       "engines": {
         "node": ">=18"
@@ -2607,12 +2607,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gr4vy/sdk",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "author": "Gr4vy",
   "main": "./index.js",
   "sideEffects": false,
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "jsonwebtoken": "^9.0.3",
-    "snakecase-keys": "^6.0.0",
+    "snakecase-keys": "^8.1.0",
     "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -77,7 +77,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "2.0.32",
+  sdkVersion: "2.0.33",
   genVersion: "2.881.4",
-  userAgent: "speakeasy-sdk/typescript 2.0.32 2.881.4 1.0.0 @gr4vy/sdk",
+  userAgent: "speakeasy-sdk/typescript 2.0.33 2.881.4 1.0.0 @gr4vy/sdk",
 } as const;


### PR DESCRIPTION
## Summary

- Bump `snakecase-keys` from `^6.0.0` → **`^8.1.0`** in [.speakeasy/gen.yaml](.speakeasy/gen.yaml). v8 is the latest CommonJS-compatible major; v9 went ESM-only and would re-trigger the TS1479 build error that #245 just fixed for `uuid`.
- Regenerate the SDK to **2.0.33** as a result of the gen.yaml change.

## Dep audit (the rest of gen.yaml)

| Dep | Current | Latest | Action |
|---|---|---|---|
| `jsonwebtoken` | ^9.0.3 | 9.0.3 | already latest |
| `@types/jsonwebtoken` | ^9.0.10 | 9.0.10 | already latest |
| `timekeeper` | ^2.3.1 | 2.3.1 | already latest |
| `vitest` | ^4.1.5 | 4.1.5 | already latest |
| `snakecase-keys` | ^6.0.0 | 9.0.2 (ESM) | **bumped to ^8.1.0** (latest CJS) |

Replaces #246 (which was stacked on the pre-merge `feat-bump-deps`); this branch is built fresh against current `main` post-#245.

## Test plan

- [x] `speakeasy run` succeeds (lint + build green during regen)
- [x] `npx vitest run tests/auth.test.js tests/webhook.test.ts` — 13/13 pass, including the auth tests that exercise the `snakeCaseKeys` codepath in [src/lib/auth.ts](src/lib/auth.ts)
- [ ] `tests/checkout-sessions.test.ts` — pre-existing 401 against the sandbox, reproduces on `main`, unrelated