### PR TITLE
ci: increase test timeouts and fix matrix node-version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     
-    timeout-minutes: 3
+    timeout-minutes: 10
     strategy:
       matrix:
-        node:
+        node-version:
           - 20.x
           - 22.x
           - 24.x
@@ -44,7 +44,7 @@ jobs:
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: |
-          npx vitest --testTimeout 8000   
+          npx vitest run --testTimeout=30000 --hookTimeout=30000
 
       - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
         if: ${{ success() && github.event.pull_request.user.login == 'github-actions[bot]' }}


### PR DESCRIPTION
## Summary

- Bump Vitest `--testTimeout` from 8s to 30s and add a matching `--hookTimeout=30000` so `beforeAll` setup is also covered.
- Fix the matrix key `node:` → `node-version:` so `actions/setup-node` actually receives a version (the matrix was previously a no-op — all three jobs ran on Node 20.20.2).
- Raise job `timeout-minutes` from 3 to 10.
- Use `vitest run` explicitly.

## Why

CI has been intermittently failing with `Error: Test timed out in 8000ms` on the e2e test `should process a payment with a checkout session`. That test is genuinely end-to-end against `api.sandbox.e2e.gr4vy.app` — it creates a merchant account, payment service, checkout session, PUTs card fields, and creates a transaction (5 sequential network round-trips). Logs from runs [25098327535](https://github.com/gr4vy/gr4vy-typescript/actions/runs/25098327535) and [23532353877](https://github.com/gr4vy/gr4vy-typescript/actions/runs/23532353877) show it sometimes runs ~14–17s before being killed. 30s gives comfortable headroom.

While editing, I also noticed the matrix typo and fixed it in the same change.

## Out of scope

A separate bug exists in `tests/utils/setup.ts`: the custom fetcher injects an unexpected JSON field into _every_ response including 5xx bodies, which makes the SDK's `Error500` Zod transform throw on real sandbox 500s (seen in run [25116271293](https://github.com/gr4vy/gr4vy-typescript/actions/runs/25116271293)). Not a timeout — left for a follow-up.

## Test plan

- [ ] CI runs on this PR — confirm all three matrix jobs report different Node versions (20.x / 22.x / 24.x) instead of the same 20.20.2.
- [ ] The flaky `should process a payment with a checkout session` test passes.
- [ ] Re-run the workflow a few times to confirm stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)