### PR TITLE
ci: gate auto-merge on a stable ci-complete check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,8 +71,30 @@ jobs:
         run: |
           npx vitest run --testTimeout=30000 --hookTimeout=30000 --shard=${{ matrix.shard }}/4
 
-      - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
-        if: ${{ success() && github.event.pull_request.user.login == 'github-actions[bot]' }}
+  # Single, stable status check that gates merge. The `test` job fans out across a
+  # node × shard matrix, so its per-job names ("test (20.x, 1)" …) change whenever
+  # the matrix changes — which silently breaks any branch ruleset that requires
+  # the old names. This job gives the ruleset one fixed context ("ci-complete") to
+  # require, and it only succeeds when every shard passed. It also performs the
+  # auto-approve once, after all shards are green, rather than prematurely per
+  # shard.
+  ci-complete:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Verify all test shards passed
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "test matrix result: ${{ needs.test.result }}"
+            exit 1
+          fi
+      - name: Auto-approve generated SDK PRs
+        if: ${{ github.event.pull_request.user.login == 'github-actions[bot]' }}
+        uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
         with:
           github-token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
 
@@ -133,7 +155,7 @@ jobs:
           path: coverage/endpoint-coverage.md
 
   merge:
-    needs: test
+    needs: ci-complete
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Problem

Generated SDK PRs (e.g. #277) fail auto-merge: the `merge` job polls
`mergeable_state` and gets `blocked` for all 6 retries, then errors.

Root cause: the `main` ruleset requires status checks **`test (20.x)`,
`test (22.x)`, `test (24.x)`**. Adding the `shard` matrix axis renamed those
jobs to `test (20.x, 1)` … `test (24.x, 4)`, so the *required* contexts never
report and the PR stays blocked permanently. (The PR is even auto-approved — it's
purely the missing required checks.)

## Fix

- Add a single **`ci-complete`** job that `needs: test`, succeeds only when the
  whole matrix passed, and performs the auto-approve **once** (after all shards),
  instead of prematurely per shard.
- Point `merge` at `ci-complete`.
- The `main` ruleset's required status check should be changed to **`ci-complete`**
  (one stable context, robust to future matrix/shard changes).

## Bootstrap note

Because CI runs via `pull_request_target` (base workflow), this PR can't display
its own new `ci-complete` check, so it needs a one-time admin merge; the ruleset
required-check is then switched to `ci-complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)