### PR TITLE
feat(auth): add getEmbedTokenWithCheckoutSession helper

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,1 +1,3 @@
 src/index.ts
+src/lib/auth.ts
+tests/auth.test.js

--- a/README.md
+++ b/README.md
@@ -170,6 +170,43 @@ run();
 > **Note:** This will only create a token once. Use `withToken` to dynamically generate a token
 > for every request.
 
+### Attaching a checkout session automatically
+
+For Embed, it is recommended to attach a checkout session to every transaction. The
+`getEmbedTokenWithCheckoutSession` helper creates a checkout session using your SDK client and
+returns an Embed token with the resulting `checkout_session_id` already pinned, in a single call.
+
+```js
+import { Gr4vy, getEmbedTokenWithCheckoutSession, withToken } from "@gr4vy/sdk";
+
+async function run() {
+    const privateKey = fs.readFileSync("private_key.pem", "utf8")
+
+    const gr4vy = new Gr4vy({
+        server: "sandbox",
+        id: "example",
+        bearerAuth: withToken({ privateKey }),
+    });
+
+    const token = await getEmbedTokenWithCheckoutSession({
+      client: gr4vy,
+      privateKey,
+      embedParams: {
+        amount: 1299,
+        currency: 'USD',
+        buyerExternalIdentifier: 'user-1234',
+      }
+    });
+
+    console.log(token);
+}
+
+run();
+```
+
+You can optionally pass a `checkoutSession` body to seed the session (for example with cart items
+or metadata), and a `merchantAccountId` to override the client's configured merchant account.
+
 ## Merchant account ID selection
 
 Depending on the key used, you might need to explicitly define a merchant account ID to use. In our API, 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ For Embed, it is recommended to attach a checkout session to every transaction. 
 returns an Embed token with the resulting `checkout_session_id` already pinned, in a single call.
 
 ```js
+import fs from "node:fs";
 import { Gr4vy, getEmbedTokenWithCheckoutSession, withToken } from "@gr4vy/sdk";
 
 async function run() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from "./sdk";
 
 export {
     getEmbedToken,
+    getEmbedTokenWithCheckoutSession,
     getToken,
     JWTScope,
     updateToken,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,9 +3,11 @@ import jwt, { JwtPayload } from "jsonwebtoken";
 import type { StringValue } from "ms";
 import snakeCaseKeys from "snakecase-keys";
 
-import { CartItem } from "../models/components";
+import { CartItem, CheckoutSessionCreate } from "../models/components";
 import { SDK_METADATA } from "./config";
 import { getKeyId } from "./helpers";
+
+import type { Gr4vy } from "../sdk/sdk";
 
 /**
  * Helper method for generating a bearer token for use with the SDK
@@ -119,6 +121,39 @@ export const getEmbedToken = async (options: {
     expiresIn: '1h'
    })
 }
+
+/**
+ * Helper method that creates a checkout session and returns an Embed token with
+ * the new checkout session ID baked in.
+ *
+ * This is a convenience wrapper around `getEmbedToken` for the common Embed flow
+ * where every transaction should be tied to a checkout session. It uses the
+ * provided (already authenticated) SDK client to create the checkout session,
+ * then signs an Embed token that pins the resulting `checkout_session_id`.
+ */
+export const getEmbedTokenWithCheckoutSession = async (options: {
+  client: Gr4vy;
+  privateKey: string;
+  embedParams?: EmbedParams;
+  /** Optional checkout session body to seed cart items, metadata, and so on. */
+  checkoutSession?: CheckoutSessionCreate;
+  /** Optional merchant account ID override. Defaults to the client's configured one. */
+  merchantAccountId?: string;
+}): Promise<string> => {
+  const { client, privateKey, embedParams, checkoutSession, merchantAccountId } =
+    options;
+
+  const session = await client.checkoutSessions.create(
+    checkoutSession,
+    merchantAccountId,
+  );
+
+  return getEmbedToken({
+    privateKey,
+    ...(embedParams ? { embedParams } : {}),
+    checkoutSessionId: session.id,
+  });
+};
 
 /**
  * Short hands for scopes. Strings can be used as well.

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -3,7 +3,8 @@ import snakecaseKeys from "snakecase-keys";
 import timekeeper from "timekeeper";
 import { describe, expect, test } from "vitest";
 import { version } from "../package.json";
-import { getEmbedToken, getToken, JWTScope, updateToken, SDK_METADATA } from "../src";
+import { getEmbedToken, getEmbedTokenWithCheckoutSession, getToken, JWTScope, updateToken, SDK_METADATA } from "../src";
+import { vi } from "vitest";
 
 const privateKey = `-----BEGIN PRIVATE KEY-----
 MIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIBABM9jQu+HT87oIik
@@ -139,6 +140,50 @@ describe(".getEmbedToken", () => {
     });
 
     expect(decoded.payload.checkout_session_id).toEqual(checkoutSessionId);
+  });
+});
+
+describe(".getEmbedTokenWithCheckoutSession", () => {
+  test("should create a checkout session and pin its ID in the Embed token", async () => {
+    const create = vi.fn().mockResolvedValue({ id: checkoutSessionId });
+    const client = { checkoutSessions: { create } };
+
+    const token = await getEmbedTokenWithCheckoutSession({
+      client,
+      privateKey,
+      embedParams,
+    });
+
+    const decoded = jwt.verify(token, privateKey, {
+      algorithms: ["ES512"],
+      complete: true,
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(decoded.payload.scopes).toEqual(["embed"]);
+    expect(decoded.payload.checkout_session_id).toEqual(checkoutSessionId);
+
+    const connOptions =
+      embedParams.connectionOptions || embedParams["connection_options"];
+    const expected = snakecaseKeys(embedParams, { exclude: ["metadata"] });
+    expected["connection_options"] = connOptions;
+    expect(decoded.payload.embed).toEqual(expected);
+  });
+
+  test("should forward the checkout session body and merchant account ID", async () => {
+    const create = vi.fn().mockResolvedValue({ id: checkoutSessionId });
+    const client = { checkoutSessions: { create } };
+
+    const checkoutSession = { metadata: { order: "123" } };
+
+    await getEmbedTokenWithCheckoutSession({
+      client,
+      privateKey,
+      checkoutSession,
+      merchantAccountId: "default",
+    });
+
+    expect(create).toHaveBeenCalledWith(checkoutSession, "default");
   });
 });
 

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,10 +1,9 @@
 import jwt from "jsonwebtoken";
 import snakecaseKeys from "snakecase-keys";
 import timekeeper from "timekeeper";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { version } from "../package.json";
 import { getEmbedToken, getEmbedTokenWithCheckoutSession, getToken, JWTScope, updateToken, SDK_METADATA } from "../src";
-import { vi } from "vitest";
 
 const privateKey = `-----BEGIN PRIVATE KEY-----
 MIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIBABM9jQu+HT87oIik

--- a/tests/flows/transaction-lifecycle.test.ts
+++ b/tests/flows/transaction-lifecycle.test.ts
@@ -84,6 +84,36 @@ describe("Transaction lifecycle", () => {
     expect(topLevel.id).toBe(firstRefundId);
   });
 
+  test("authorize → capture → read captures back via list and get", async () => {
+    const transaction = await authorize(4500);
+    expect(transaction.status).toBe("authorization_succeeded");
+
+    unwrapTransaction(
+      await gr4vy.transactions.capture({
+        transactionId: transaction.id,
+        transactionCaptureCreate: { amount: 4500 },
+      })
+    );
+
+    // Wait until the capture is recorded against the transaction.
+    await pollUntil(
+      () => gr4vy.transactions.get(transaction.id),
+      (t) => t.status === "capture_succeeded",
+      { description: "capture to succeed" }
+    );
+
+    // List captures, then read one back by id.
+    const captures = await gr4vy.transactions.captures.list(transaction.id);
+    expect(captures.items.length).toBeGreaterThanOrEqual(1);
+
+    const captureId = captures.items[0]!.id;
+    const fetched = await gr4vy.transactions.captures.get(
+      transaction.id,
+      captureId
+    );
+    expect(fetched.id).toBe(captureId);
+  });
+
   test("authorize → void releases the authorization", async () => {
     const transaction = await authorize(3300);
     expect(transaction.status).toBe("authorization_succeeded");


### PR DESCRIPTION
## What

Adds an opt-in `getEmbedTokenWithCheckoutSession` helper (idiomatic per language) that creates a checkout session via the SDK client and returns an Embed token with the resulting `checkout_session_id` already pinned — in a single call.

This makes it neat for merchants to ensure **every Embed transaction is tied to a checkout session**, without manually creating the session and threading its ID into the token call.

## Details

- **Non-breaking**: the existing `getEmbedToken` signature is unchanged. Passing the SDK client into the new helper is the opt-in.
- Accepts an optional checkout session body (cart items, metadata, etc.) and an optional merchant-account override; defaults to an empty session using the client's configured merchant account.
- The hand-written auth source and its test are now protected from Speakeasy regeneration via `.genignore`.
- New unit test covers: a checkout session is created exactly once and the returned token carries the `embed` scope and the pinned `checkout_session_id`.
- README "Embed token generation" section documents the new helper (these sections live outside Speakeasy's managed `<!-- Start/End -->` regions, so they survive regen).

Docs PR (token quickstart + JWT guide) is in `gr4vy-docs-mintlify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
