### PR TITLE
test: cover API key pairs and transaction refund settlements endpoints

### DIFF
--- a/tests/backoffice/api-key-pairs.test.ts
+++ b/tests/backoffice/api-key-pairs.test.ts
@@ -1,0 +1,52 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { Gr4vy } from "../../src";
+import { createGr4vyClient, setupMerchant } from "../utils/setup";
+
+let admin: Gr4vy;
+
+// A nonexistent id used to exercise get/update/delete at the request level: the
+// SDK serialises and sends the request, and the API rejects it with a 4xx.
+const MISSING_ID = "00000000-0000-0000-0000-000000000000";
+
+beforeAll(async () => {
+  // API key pairs are an account-level resource (not merchant-scoped), so use an
+  // un-scoped client — mirrors the merchant-accounts suite.
+  const { privateKey } = await setupMerchant();
+  admin = createGr4vyClient(privateKey);
+});
+
+describe("API Key Pairs", () => {
+  test("listing API key pairs returns a page", async () => {
+    const page = await admin.apiKeyPairs.list();
+    expect(page).toBeDefined();
+  });
+
+  // create/get/update/delete are exercised at the request level rather than as a
+  // happy path: creating a real key pair requires an existing role, and the
+  // sandbox merchant is not provisioned with one. Passing a nonexistent role id
+  // still serialises the payload and reaches the server (which rejects it with a
+  // 4xx), so the operation counts as reached by the HTTP-coverage check.
+  test("create is exercised at the request level", async () => {
+    await expect(
+      admin.apiKeyPairs.create({
+        displayName: "E2E API key pair",
+        roleIds: [MISSING_ID],
+      })
+    ).rejects.toThrow();
+  });
+
+  test("fetching a missing API key pair is exercised at the request level", async () => {
+    await expect(admin.apiKeyPairs.get(MISSING_ID)).rejects.toThrow();
+  });
+
+  test("updating a missing API key pair is exercised at the request level", async () => {
+    // Note the argument order: the update body comes first, then the id.
+    await expect(
+      admin.apiKeyPairs.update({ displayName: "Renamed" }, MISSING_ID)
+    ).rejects.toThrow();
+  });
+
+  test("deleting a missing API key pair is exercised at the request level", async () => {
+    await expect(admin.apiKeyPairs.delete(MISSING_ID)).rejects.toThrow();
+  });
+});

--- a/tests/processing/transactions.test.ts
+++ b/tests/processing/transactions.test.ts
@@ -116,3 +116,31 @@ describe("Transactions", () => {
     );
   });
 });
+
+describe("Transaction refund settlements", () => {
+  // A nonexistent id used to exercise get at the request level: the SDK
+  // serialises and sends the request, and the API rejects it with a 4xx.
+  const MISSING_ID = "00000000-0000-0000-0000-000000000000";
+
+  test("listing refund settlements returns a result", async () => {
+    const created = await authorizeViaCheckoutSession(gr4vy, 1299);
+
+    const settlements = await gr4vy.transactions.refundSettlements.list(
+      created.id
+    );
+    expect(settlements).toBeDefined();
+  });
+
+  // Fetching a specific refund settlement is exercised at the request level: a
+  // real refund settlement only exists once a refund has settled, which the
+  // sandbox can't force synchronously. Targeting a nonexistent settlement id
+  // still sends the request (rejected with a 4xx), so the operation counts as
+  // reached by the HTTP-coverage check.
+  test("fetching a missing refund settlement is exercised at the request level", async () => {
+    const created = await authorizeViaCheckoutSession(gr4vy, 1299);
+
+    await expect(
+      gr4vy.transactions.refundSettlements.get(created.id, MISSING_ID)
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## The gap

CI's endpoint-coverage check computes reach from *observed HTTP calls* (see the comment in `tests/utils/setup.ts`) — an operation only counts as reached if a request actually goes out. Two resources had operations showing as unreached:

- **API key pairs** (`gr4vy.apiKeyPairs`): list / create / get / update / delete — zero tests.
- **Transaction refund settlements** (`gr4vy.transactions.refundSettlements`): `list` (`GET /transactions/{id}/refund-settlements`) and `get` (`GET /transactions/{id}/refund-settlements/{settlement_id}`) — zero tests.

## The design

Both follow the existing backoffice/processing conventions (`payouts.test.ts`, `merchant-accounts.test.ts`, `checkout-sessions.test.ts`): happy-path for reads that always succeed, and "exercised at the request level" (`await expect(...).rejects.toThrow()`) for operations that need state the sandbox can't force but which still send a real request the API rejects with a 4xx.

### `tests/backoffice/api-key-pairs.test.ts` (new)

- **list → happy path**: `admin.apiKeyPairs.list()` returns a page.
- **create / get / update / delete → request level**: creating a real key pair needs an existing role the sandbox merchant lacks, so `create` passes a nonexistent role id; `get` / `update` / `delete` target a nonexistent UUID.
- API key pairs are an **account-level** resource, so the suite uses an un-scoped admin client (`createGr4vyClient(privateKey)`), matching `merchant-accounts.test.ts`.

### `tests/processing/transactions.test.ts` (extended)

New "Transaction refund settlements" block:
- **list → happy path**: `refundSettlements.list(transactionId)` on a freshly authorised transaction returns a result.
- **get → request level**: a specific refund settlement only exists once a refund has settled (not forceable in the sandbox), so `refundSettlements.get(transactionId, MISSING_ID)` uses a nonexistent settlement id.

## Verification

- `tsc --noEmit` over `src` + both test files: clean.
- `eslint` on both files: clean.
- The live vitest suite was **not** run here (needs sandbox credentials); it runs in CI.