### PR TITLE
ci: drop EOL Node 20 and run single LTS on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,25 +12,42 @@ on:
     - cron: 30 8 * * 1-5
 
 jobs:
-  test:
+  # Compute the Node matrix per event. Every shard hits the real E2E sandbox, so
+  # each extra Node version multiplies the number of live-API jobs (and the odds
+  # that a transient upstream 5xx reddens the merge gate). PRs therefore run a
+  # single current LTS (24.x) for fast, low-flake signal, while push / schedule /
+  # dispatch run the broader matrix so version-specific regressions are still
+  # caught daily. Node 20 is dropped everywhere (EOL 2026-04-30).
+  setup:
     runs-on: ubuntu-latest
     # The suite runs against the real E2E sandbox with PRIVATE_KEY. On
     # pull_request_target the workflow runs with repo secrets, so restrict the
     # secret-backed matrix to same-repo PRs (e.g. the generated SDK PRs) plus
-    # push/schedule/dispatch. This stops forked PRs from spinning up a 3×4 matrix
-    # of secret-backed sandbox calls (a cost / DoS vector), while the secret
-    # itself was never exposed to fork code (the PR head isn't checked out).
+    # push/schedule/dispatch. This stops forked PRs from spinning up a matrix of
+    # secret-backed sandbox calls (a cost / DoS vector), while the secret itself
+    # was never exposed to fork code (the PR head isn't checked out).
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      node-versions: ${{ steps.matrix.outputs.node-versions }}
+    steps:
+      - id: matrix
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            echo 'node-versions=["24.x"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'node-versions=["22.x","24.x"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    needs: setup
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        node-version:
-          - 20.x
-          - 22.x
-          - 24.x
+        node-version: ${{ fromJSON(needs.setup.outputs.node-versions) }}
         # The E2E suite is split into shards that run in parallel. Each test file
         # provisions its own merchant account, so vitest can safely distribute the
         # files across shards. Bump `shard-total` (and this list) to add capacity.


### PR DESCRIPTION
## Why

Every CI shard hits the real E2E sandbox with `PRIVATE_KEY`, so each Node version in the matrix multiplies the number of live-API jobs — and the chance that a single transient upstream `5xx` reddens the `ci-complete` merge gate. That's exactly what failed [PR #313](https://github.com/gr4vy/gr4vy-typescript/pull/313): a sandbox `500` in one of 12 jobs, unrelated to the change.

On top of that, **Node 20 reached EOL on 2026-04-30**, so a third of the matrix was testing an unmaintained runtime.

## What

- **Drop Node 20** everywhere.
- **Compute the Node matrix per event** via a small `setup` job:
  - **PRs** run a single current LTS — **24.x** (4 jobs) — for fast, low-flake signal.
  - **push / schedule / dispatch** run the broader **{22.x, 24.x}** matrix (8 jobs) so version-specific regressions are still caught daily.
- Shard×4 split is unchanged (each shard provisions its own merchant account).

This is an HTTP SDK (fetch/JSON/crypto — stable across modern LTS), so the Node dimension adds little signal per-PR relative to the flakiness and sandbox cost it introduces.

## Notes

- The same-repo / fork guard is preserved (moved onto `setup`; `test` inherits it via `needs`). Fork PRs still skip the secret-backed jobs.
- `coverage`, `merge`, and `notify` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)