### PR TITLE
test: cover gift-card activations/issuances and authorization increment

### DIFF
--- a/tests/processing/gift-cards.test.ts
+++ b/tests/processing/gift-cards.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
+import { reaches } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -41,5 +42,32 @@ describe("Gift Cards", () => {
     const bogus = "00000000-0000-0000-0000-000000000000";
     await expect(gr4vy.giftCards.get(bogus)).rejects.toThrow();
     await expect(gr4vy.giftCards.delete(bogus)).rejects.toThrow();
+  });
+
+  // Activation and issuance both need a configured gift-card service, so they
+  // are asserted via `reaches` — a 2xx or a clean 4xx passes, a 5xx fails.
+  test("activation is exercised at the request level", async () => {
+    await reaches(
+      () =>
+        gr4vy.giftCards.activations.create({
+          number: "4111111111111111",
+          pin: "1234",
+          amount: 1299,
+          currency: "USD",
+        }),
+      "giftCards.activations.create"
+    );
+  });
+
+  test("issuance is exercised at the request level", async () => {
+    await reaches(
+      () =>
+        gr4vy.giftCards.issuances.create({
+          theme: "default",
+          amount: 1299,
+          currency: "USD",
+        }),
+      "giftCards.issuances.create"
+    );
   });
 });

--- a/tests/processing/transactions.test.ts
+++ b/tests/processing/transactions.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { amount, currency, fcParams, metadata } from "../utils/arbitraries";
 import { buyer, cardPaymentMethod, uniqueId } from "../utils/fixtures";
+import { reaches } from "../utils/reach";
 import { authorizeViaCheckoutSession } from "../utils/transactions";
 import { setupMerchant } from "../utils/setup";
 
@@ -142,5 +143,19 @@ describe("Transaction refund settlements", () => {
     await expect(
       gr4vy.transactions.refundSettlements.get(created.id, MISSING_ID)
     ).rejects.toThrow();
+  });
+});
+
+// Incremental authorization is a PSP capability the mock connector does not
+// offer. We authorize for real first so the increment is attempted against a
+// genuinely authorized transaction, then accept a clean rejection.
+describe("Transaction authorization increment", () => {
+  test("incrementing an authorization is exercised at the request level", async () => {
+    const created = await authorizeViaCheckoutSession(gr4vy, 1299);
+
+    await reaches(
+      () => gr4vy.transactions.incrementAuthorization({ amount: 500 }, created.id),
+      "transactions.incrementAuthorization"
+    );
   });
 });

--- a/tests/utils/reach.ts
+++ b/tests/utils/reach.ts
@@ -1,0 +1,41 @@
+import { Gr4vyError } from "../../src/models/errors";
+
+/**
+ * Assert that an operation *reaches the server* — the point being that the
+ * endpoint-reach report counts operations by observed HTTP calls, so the value
+ * of these tests is proving a well-formed request went out over the wire.
+ *
+ * Some operations cannot be driven to a 2xx in the mock-card sandbox (a
+ * configured gift-card service, a PSP that supports incremental authorization),
+ * so a clean 4xx is an acceptable outcome alongside a 2xx.
+ *
+ * A **5xx fails**: that means we sent something the API could not handle, which
+ * is a real defect worth surfacing. A failure that never hit the wire (local
+ * validation, serialization, connection refused) also fails — plain
+ * `rejects.toThrow()` would silently accept those and prove nothing.
+ */
+export const reaches = async (
+  action: () => Promise<unknown>,
+  description: string
+): Promise<void> => {
+  try {
+    await action();
+    return; // reached + succeeded (2xx)
+  } catch (error) {
+    if (error instanceof Gr4vyError) {
+      const { statusCode } = error;
+      if (statusCode >= 500) {
+        throw new Error(
+          `[reach] ${description}: server error (${statusCode}): ${error.message}`
+        );
+      }
+      // 4xx, or a response the SDK could not fully parse — either way the
+      // endpoint was reached.
+      return;
+    }
+    throw new Error(
+      `[reach] ${description}: the call failed before reaching the server: ` +
+        `${(error as Error)?.name} — ${(error as Error)?.message}`
+    );
+  }
+};


### PR DESCRIPTION
## Why

The endpoint-reach report has been sitting at **116 / 119** on every SDK. The same three operations were never hitting the wire:

- `giftCardsActivationsCreate`
- `giftCardsIssuancesCreate`
- `transactionsIncrementAuthorization`

This closes the gap for TypeScript. Companion PRs cover the other five SDKs.

## What

- `tests/utils/reach.ts` — new `reaches` helper
- `tests/processing/gift-cards.test.ts` — activation + issuance
- `tests/processing/transactions.test.ts` — authorization increment

All three need capabilities the mock-card merchant does not have (a configured gift-card service; a PSP that supports incremental authorization), so none can be driven to a 2xx here.

### On the new helper

Reach is measured from **observed HTTP calls**, so these tests are only worth something if a well-formed request actually goes out. A bare `rejects.toThrow()` — the existing convention — also passes when the SDK throws locally before anything reaches the wire, which would prove nothing while still looking green. `reaches` accepts a 2xx or a clean 4xx, and fails on a 5xx or on any failure that never reached the server. I left the existing assertions alone rather than widen this PR.

The increment test authorizes a real transaction first, so the increment is attempted against a genuinely authorized transaction rather than a missing id.

## Verification

`tsc --noEmit` is clean and all three tests register with vitest. I could not run the live suite locally (no sandbox signing key), so the `coverage` job on this PR is the verification — it should report **119 / 119**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)