### PR TITLE
test: use reach assertions across the whole suite

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -94,6 +94,27 @@ request level** — the SDK serialises the request and we assert the API rejects
 it for a real reason — and each is clearly commented. They are never silently
 skipped, so they still count toward endpoint reach.
 
+### `reaches` vs `rejectsClientError`
+
+Endpoint reach is measured from **HTTP requests actually sent**, so a
+request-level test is only worth something if a well-formed request left the
+process. `tests/utils/reach.ts` provides the two assertions to use — pick by
+whether the rejection is incidental or is the thing under test:
+
+| Helper | Use when | 2xx | 4xx | 5xx | Never reached the wire |
+| --- | --- | --- | --- | --- | --- |
+| `reaches` | The op can't reach a happy path here; you only need it reached | pass | pass | **fail** | **fail** |
+| `rejectsClientError` | The rejection *is* the assertion ("after delete, reading it back must 404") | **fail** | pass | **fail** | **fail** |
+
+Prefer these over a bare `rejects.toThrow()`. That assertion also passes when
+the SDK throws locally — a bad argument, a serialisation error — before anything
+is sent, so it can go green while the endpoint is never reached and the coverage
+report still counts it as untested. Both helpers fail that case explicitly.
+
+The one place a raw `expect(...).rejects` is still right is when you assert a
+*specific* error, e.g. the checkout-session validation message in
+`tests/processing/checkout-sessions.test.ts`.
+
 ## Coverage
 
 ```sh

--- a/tests/backoffice/account-updater.test.ts
+++ b/tests/backoffice/account-updater.test.ts
@@ -1,6 +1,7 @@
-import { beforeAll, describe, expect, test } from "vitest";
+import { beforeAll, describe, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { cardPaymentMethod } from "../utils/fixtures";
+import { reaches } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -17,8 +18,9 @@ describe("Account Updater", () => {
   test("creating a job is exercised at the request level", async () => {
     const method = await gr4vy.paymentMethods.create(cardPaymentMethod());
 
-    await expect(
-      gr4vy.accountUpdater.jobs.create({ paymentMethodIds: [method.id] })
-    ).rejects.toThrow();
+    await reaches(
+      () => gr4vy.accountUpdater.jobs.create({ paymentMethodIds: [method.id] }),
+      "accountUpdater.jobs.create"
+    );
   });
 });

--- a/tests/backoffice/api-key-pairs.test.ts
+++ b/tests/backoffice/api-key-pairs.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
+import { reaches } from "../utils/reach";
 import { createGr4vyClient, setupMerchant } from "../utils/setup";
 
 let admin: Gr4vy;
@@ -27,26 +28,32 @@ describe("API Key Pairs", () => {
   // still serialises the payload and reaches the server (which rejects it with a
   // 4xx), so the operation counts as reached by the HTTP-coverage check.
   test("create is exercised at the request level", async () => {
-    await expect(
-      admin.apiKeyPairs.create({
-        displayName: "E2E API key pair",
-        roleIds: [MISSING_ID],
-      })
-    ).rejects.toThrow();
+    await reaches(
+      () =>
+        admin.apiKeyPairs.create({
+          displayName: "E2E API key pair",
+          roleIds: [MISSING_ID],
+        }),
+      "apiKeyPairs.create"
+    );
   });
 
   test("fetching a missing API key pair is exercised at the request level", async () => {
-    await expect(admin.apiKeyPairs.get(MISSING_ID)).rejects.toThrow();
+    await reaches(() => admin.apiKeyPairs.get(MISSING_ID), "apiKeyPairs.get");
   });
 
   test("updating a missing API key pair is exercised at the request level", async () => {
     // Note the argument order: the update body comes first, then the id.
-    await expect(
-      admin.apiKeyPairs.update({ displayName: "Renamed" }, MISSING_ID)
-    ).rejects.toThrow();
+    await reaches(
+      () => admin.apiKeyPairs.update({ displayName: "Renamed" }, MISSING_ID),
+      "apiKeyPairs.update"
+    );
   });
 
   test("deleting a missing API key pair is exercised at the request level", async () => {
-    await expect(admin.apiKeyPairs.delete(MISSING_ID)).rejects.toThrow();
+    await reaches(
+      () => admin.apiKeyPairs.delete(MISSING_ID),
+      "apiKeyPairs.delete"
+    );
   });
 });

--- a/tests/backoffice/payment-services.test.ts
+++ b/tests/backoffice/payment-services.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { PaymentServiceCreate } from "../../src/models/components";
+import { reaches, rejectsClientError } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -39,26 +40,32 @@ describe("Payment Services", () => {
     expect(updated.displayName).toBe("Renamed service");
 
     await gr4vy.paymentServices.delete(created.id!);
-    await expect(() => gr4vy.paymentServices.get(created.id!)).rejects.toThrow();
+    await rejectsClientError(
+      () => gr4vy.paymentServices.get(created.id!),
+      "paymentServices.get after delete"
+    );
   });
 
   // Credential verification and session creation are not meaningfully supported
   // by the mock-card connector (verify returns a non-JSON body; session is
   // explicitly unsupported), so both are exercised at the request level.
   test("verify is exercised at the request level", async () => {
-    await expect(
-      gr4vy.paymentServices.verify({
-        paymentServiceDefinitionId: "mock-card",
-        fields: [{ key: "merchant_id", value: "test" }],
-      })
-    ).rejects.toThrow();
+    await reaches(
+      () =>
+        gr4vy.paymentServices.verify({
+          paymentServiceDefinitionId: "mock-card",
+          fields: [{ key: "merchant_id", value: "test" }],
+        }),
+      "paymentServices.verify"
+    );
   });
 
   test("create a session is exercised at the request level", async () => {
     const created = await gr4vy.paymentServices.create(mockCardService());
-    await expect(
-      gr4vy.paymentServices.session({}, created.id!)
-    ).rejects.toThrow();
+    await reaches(
+      () => gr4vy.paymentServices.session({}, created.id!),
+      "paymentServices.session"
+    );
   });
 
   describe("definitions, options and card schemes", () => {
@@ -73,9 +80,10 @@ describe("Payment Services", () => {
 
     test("create a session for a definition is exercised at the request level", async () => {
       // Session creation is not supported for the mock-card definition.
-      await expect(
-        gr4vy.paymentServiceDefinitions.session({}, "mock-card")
-      ).rejects.toThrow();
+      await reaches(
+        () => gr4vy.paymentServiceDefinitions.session({}, "mock-card"),
+        "paymentServiceDefinitions.session"
+      );
     });
 
     test("list payment options for a cart", async () => {

--- a/tests/backoffice/payouts.test.ts
+++ b/tests/backoffice/payouts.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { APPROVING_CARD } from "../utils/fixtures";
+import { reaches } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -27,23 +28,26 @@ describe("Payouts", () => {
       fields: [{ key: "merchant_id", value: "test" }],
     });
 
-    await expect(
-      gr4vy.payouts.create({
-        amount: 1299,
-        currency: "USD",
-        paymentServiceId: service.id,
-        paymentMethod: {
-          method: "card",
-          number: APPROVING_CARD.number,
-          expirationDate: APPROVING_CARD.expiration_date,
-        },
-      })
-    ).rejects.toThrow();
+    await reaches(
+      () =>
+        gr4vy.payouts.create({
+          amount: 1299,
+          currency: "USD",
+          paymentServiceId: service.id,
+          paymentMethod: {
+            method: "card",
+            number: APPROVING_CARD.number,
+            expirationDate: APPROVING_CARD.expiration_date,
+          },
+        }),
+      "payouts.create"
+    );
   });
 
   test("fetching a missing payout is exercised at the request level", async () => {
-    await expect(
-      gr4vy.payouts.get("00000000-0000-0000-0000-000000000000")
-    ).rejects.toThrow();
+    await reaches(
+      () => gr4vy.payouts.get("00000000-0000-0000-0000-000000000000"),
+      "payouts.get"
+    );
   });
 });

--- a/tests/backoffice/reports.test.ts
+++ b/tests/backoffice/reports.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { ReportCreate } from "../../src/models/components";
 import { uniqueId } from "../utils/fixtures";
+import { reaches } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -61,9 +62,13 @@ describe("Reports", () => {
     const created = await gr4vy.reports.create(reportCreate());
     const bogus = "00000000-0000-0000-0000-000000000000";
 
-    await expect(gr4vy.reports.executions.get(bogus)).rejects.toThrow();
-    await expect(
-      gr4vy.reports.executions.url(created.id, bogus)
-    ).rejects.toThrow();
+    await reaches(
+      () => gr4vy.reports.executions.get(bogus),
+      "reports.executions.get"
+    );
+    await reaches(
+      () => gr4vy.reports.executions.url(created.id, bogus),
+      "reports.executions.url"
+    );
   });
 });

--- a/tests/flows/buyer-lifecycle.test.ts
+++ b/tests/flows/buyer-lifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   cardPaymentMethod,
   uniqueId,
 } from "../utils/fixtures";
+import { rejectsClientError } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -69,6 +70,9 @@ describe("Buyer lifecycle", () => {
     expect(created.billingDetails?.firstName).toBe("Grace");
 
     await gr4vy.buyers.delete(created.id!);
-    await expect(() => gr4vy.buyers.get(created.id!)).rejects.toThrow();
+    await rejectsClientError(
+      () => gr4vy.buyers.get(created.id!),
+      "buyers.get after delete"
+    );
   });
 });

--- a/tests/flows/transaction-lifecycle.test.ts
+++ b/tests/flows/transaction-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../utils/fixtures";
 import { putCheckoutSessionCard } from "../utils/fields";
 import { pollUntil } from "../utils/poll";
+import { reaches } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -140,7 +141,10 @@ describe("Transaction lifecycle", () => {
   // rejects it with a clear "not supported" error.
   test("authorize → cancel is exercised at the request level", async () => {
     const transaction = await authorize(1500);
-    await expect(gr4vy.transactions.cancel(transaction.id)).rejects.toThrow();
+    await reaches(
+      () => gr4vy.transactions.cancel(transaction.id),
+      "transactions.cancel"
+    );
   });
 
   test("intent=capture authorizes and captures in one step", async () => {
@@ -164,18 +168,23 @@ describe("Transaction lifecycle", () => {
 
     // No settlement exists yet for a freshly captured transaction in the mock
     // env, so fetching one by id is exercised at the request level.
-    await expect(
-      gr4vy.transactions.settlements.get(
-        transaction.id,
-        "00000000-0000-0000-0000-000000000000"
-      )
-    ).rejects.toThrow();
+    await reaches(
+      () =>
+        gr4vy.transactions.settlements.get(
+          transaction.id,
+          "00000000-0000-0000-0000-000000000000"
+        ),
+      "transactions.settlements.get"
+    );
   });
 
   // `sync` is not supported by the mock-card connector; exercise the call shape
   // and assert the API rejects it rather than skipping the endpoint.
   test("sync is exercised at the request level", async () => {
     const transaction = await authorize(1700);
-    await expect(gr4vy.transactions.sync(transaction.id)).rejects.toThrow();
+    await reaches(
+      () => gr4vy.transactions.sync(transaction.id),
+      "transactions.sync"
+    );
   });
 });

--- a/tests/processing/buyers.test.ts
+++ b/tests/processing/buyers.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { address, billingDetails, buyer, uniqueId } from "../utils/fixtures";
 import { fcParams, name } from "../utils/arbitraries";
+import { rejectsClientError } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -23,7 +24,10 @@ describe("Buyers", () => {
     expect(page).toBeDefined();
 
     await gr4vy.buyers.delete(created.id!);
-    await expect(() => gr4vy.buyers.get(created.id!)).rejects.toThrow();
+    await rejectsClientError(
+      () => gr4vy.buyers.get(created.id!),
+      "buyers.get after delete"
+    );
   });
 
   test("can be looked up by external identifier", async () => {

--- a/tests/processing/checkout-sessions.test.ts
+++ b/tests/processing/checkout-sessions.test.ts
@@ -10,6 +10,7 @@ import {
   putCheckoutSessionCard,
   putCheckoutSessionStoredMethod,
 } from "../utils/fields";
+import { rejectsClientError } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -94,6 +95,9 @@ describe("Checkout Sessions", () => {
     expect(updated.metadata?.["source"]).toBe("updated");
 
     await gr4vy.checkoutSessions.delete(created.id);
-    await expect(() => gr4vy.checkoutSessions.get(created.id)).rejects.toThrow();
+    await rejectsClientError(
+      () => gr4vy.checkoutSessions.get(created.id),
+      "checkoutSessions.get after delete"
+    );
   });
 });

--- a/tests/processing/digital-wallets.test.ts
+++ b/tests/processing/digital-wallets.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { DigitalWallet } from "../../src/models/components";
 import { uniqueId } from "../utils/fixtures";
+import { reaches, rejectsClientError } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -51,7 +52,10 @@ describe("Digital Wallets", () => {
     expect(updated.merchantDisplayName).toBe("Renamed Display");
 
     await gr4vy.digitalWallets.delete(created.id);
-    await expect(() => gr4vy.digitalWallets.get(created.id)).rejects.toThrow();
+    await rejectsClientError(
+      () => gr4vy.digitalWallets.get(created.id),
+      "digitalWallets.get after delete"
+    );
   });
 
   // A Google Pay session can be minted server-side from an origin domain; assert
@@ -69,58 +73,71 @@ describe("Digital Wallets", () => {
   // shape is covered and the API rejects it for a real reason.
   describe("sessions exercised at the request level", () => {
     test("apple pay session", async () => {
-      await expect(
-        gr4vy.digitalWallets.sessions.applePay({
-          validationUrl: "https://apple-pay-gateway.apple.com/paymentservices",
-          domainName: "not-a-registered-domain.example.com",
-        })
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.digitalWallets.sessions.applePay({
+            validationUrl:
+              "https://apple-pay-gateway.apple.com/paymentservices",
+            domainName: "not-a-registered-domain.example.com",
+          }),
+        "digitalWallets.sessions.applePay"
+      );
     });
 
     test("click to pay session", async () => {
-      await expect(
-        gr4vy.digitalWallets.sessions.clickToPay({
-          checkoutSessionId: "00000000-0000-0000-0000-000000000000",
-        })
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.digitalWallets.sessions.clickToPay({
+            checkoutSessionId: "00000000-0000-0000-0000-000000000000",
+          }),
+        "digitalWallets.sessions.clickToPay"
+      );
     });
 
     test("paze session", async () => {
-      await expect(
-        gr4vy.digitalWallets.sessions.paze({
-          source: "web",
-          domainName: "not-a-registered-domain.example.com",
-        })
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.digitalWallets.sessions.paze({
+            source: "web",
+            domainName: "not-a-registered-domain.example.com",
+          }),
+        "digitalWallets.sessions.paze"
+      );
     });
 
     test("paze mobile session create / review / complete", async () => {
-      await expect(
-        gr4vy.digitalWallets.sessions.pazeMobileSessionCreate({
-          client: { id: "client-id" },
-          sessionId: "session-id",
-          accessToken: "access-token",
-          callbackURLScheme: "gr4vy",
-          intent: "EXPRESS_CHECKOUT",
-        })
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.digitalWallets.sessions.pazeMobileSessionCreate({
+            client: { id: "client-id" },
+            sessionId: "session-id",
+            accessToken: "access-token",
+            callbackURLScheme: "gr4vy",
+            intent: "EXPRESS_CHECKOUT",
+          }),
+        "digitalWallets.sessions.pazeMobileSessionCreate"
+      );
 
-      await expect(
-        gr4vy.digitalWallets.sessions.pazeMobileSessionReview({
-          sessionId: "session-id",
-          code: "code",
-          accessToken: "access-token",
-        })
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.digitalWallets.sessions.pazeMobileSessionReview({
+            sessionId: "session-id",
+            code: "code",
+            accessToken: "access-token",
+          }),
+        "digitalWallets.sessions.pazeMobileSessionReview"
+      );
 
-      await expect(
-        gr4vy.digitalWallets.sessions.pazeMobileSessionComplete({
-          sessionId: "session-id",
-          code: "code",
-          accessToken: "access-token",
-          transactionType: "PURCHASE",
-        })
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.digitalWallets.sessions.pazeMobileSessionComplete({
+            sessionId: "session-id",
+            code: "code",
+            accessToken: "access-token",
+            transactionType: "PURCHASE",
+          }),
+        "digitalWallets.sessions.pazeMobileSessionComplete"
+      );
     });
   });
 
@@ -130,12 +147,14 @@ describe("Digital Wallets", () => {
   describe("domains exercised at the request level", () => {
     test("domain registration is rejected", async () => {
       await withWallet(async (wallet) => {
-        await expect(
-          gr4vy.digitalWallets.domains.create(
-            { domainName: "example.com" },
-            wallet.id
-          )
-        ).rejects.toThrow();
+        await reaches(
+          () =>
+            gr4vy.digitalWallets.domains.create(
+              { domainName: "example.com" },
+              wallet.id
+            ),
+          "digitalWallets.domains.create"
+        );
       });
     });
 

--- a/tests/processing/gift-cards.test.ts
+++ b/tests/processing/gift-cards.test.ts
@@ -20,28 +20,32 @@ describe("Gift Cards", () => {
   // is provisioned only with `mock-card`, so these calls are exercised at the
   // request level and the API is expected to reject them for a real reason.
   test("create is exercised at the request level", async () => {
-    await expect(
-      gr4vy.giftCards.create({
-        number: "4111111111111111",
-        pin: "1234",
-      })
-    ).rejects.toThrow();
+    await reaches(
+      () =>
+        gr4vy.giftCards.create({
+          number: "4111111111111111",
+          pin: "1234",
+        }),
+      "giftCards.create"
+    );
   });
 
   test("balance lookup is exercised at the request level", async () => {
-    await expect(
-      gr4vy.giftCards.balances.list({
-        items: [{ number: "4111111111111111", pin: "1234" }],
-      })
-    ).rejects.toThrow();
+    await reaches(
+      () =>
+        gr4vy.giftCards.balances.list({
+          items: [{ number: "4111111111111111", pin: "1234" }],
+        }),
+      "giftCards.balances.list"
+    );
   });
 
   // No gift card exists to fetch/delete on the mock merchant, so get/delete are
   // exercised against a non-existent id and expected to be rejected.
   test("get and delete are exercised at the request level", async () => {
     const bogus = "00000000-0000-0000-0000-000000000000";
-    await expect(gr4vy.giftCards.get(bogus)).rejects.toThrow();
-    await expect(gr4vy.giftCards.delete(bogus)).rejects.toThrow();
+    await reaches(() => gr4vy.giftCards.get(bogus), "giftCards.get");
+    await reaches(() => gr4vy.giftCards.delete(bogus), "giftCards.delete");
   });
 
   // Activation and issuance both need a configured gift-card service, so they

--- a/tests/processing/payment-methods.test.ts
+++ b/tests/processing/payment-methods.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { Gr4vy } from "../../src";
 import { buyer, cardPaymentMethod } from "../utils/fixtures";
+import { reaches, rejectsClientError } from "../utils/reach";
 import { setupMerchant } from "../utils/setup";
 
 let gr4vy: Gr4vy;
@@ -24,7 +25,10 @@ describe("Payment Methods", () => {
     expect(page).toBeDefined();
 
     await gr4vy.paymentMethods.delete(created.id);
-    await expect(() => gr4vy.paymentMethods.get(created.id)).rejects.toThrow();
+    await rejectsClientError(
+      () => gr4vy.paymentMethods.get(created.id),
+      "paymentMethods.get after delete"
+    );
   });
 
   test("update changes only the expiration date (partial)", async () => {
@@ -62,29 +66,36 @@ describe("Payment Methods", () => {
       const card = await storeCard();
       const bogusToken = "00000000-0000-0000-0000-000000000000";
 
-      await expect(
-        gr4vy.paymentMethods.networkTokens.create(
-          { merchantInitiated: true, isSubsequentPayment: false },
-          card.id
-        )
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.paymentMethods.networkTokens.create(
+            { merchantInitiated: true, isSubsequentPayment: false },
+            card.id
+          ),
+        "paymentMethods.networkTokens.create"
+      );
 
-      await expect(
-        gr4vy.paymentMethods.networkTokens.suspend(card.id, bogusToken)
-      ).rejects.toThrow();
-      await expect(
-        gr4vy.paymentMethods.networkTokens.resume(card.id, bogusToken)
-      ).rejects.toThrow();
-      await expect(
-        gr4vy.paymentMethods.networkTokens.delete(card.id, bogusToken)
-      ).rejects.toThrow();
-      await expect(
-        gr4vy.paymentMethods.networkTokens.cryptogram.create(
-          { merchantInitiated: true },
-          card.id,
-          bogusToken
-        )
-      ).rejects.toThrow();
+      await reaches(
+        () => gr4vy.paymentMethods.networkTokens.suspend(card.id, bogusToken),
+        "paymentMethods.networkTokens.suspend"
+      );
+      await reaches(
+        () => gr4vy.paymentMethods.networkTokens.resume(card.id, bogusToken),
+        "paymentMethods.networkTokens.resume"
+      );
+      await reaches(
+        () => gr4vy.paymentMethods.networkTokens.delete(card.id, bogusToken),
+        "paymentMethods.networkTokens.delete"
+      );
+      await reaches(
+        () =>
+          gr4vy.paymentMethods.networkTokens.cryptogram.create(
+            { merchantInitiated: true },
+            card.id,
+            bogusToken
+          ),
+        "paymentMethods.networkTokens.cryptogram.create"
+      );
     });
   });
 
@@ -101,21 +112,25 @@ describe("Payment Methods", () => {
     // which mock-card is not; exercise the call shape at the request level.
     test("create and delete are exercised at the request level", async () => {
       const card = await storeCard();
-      await expect(
-        gr4vy.paymentMethods.paymentServiceTokens.create(
-          {
-            paymentServiceId: "00000000-0000-0000-0000-000000000000",
-            redirectUrl: "https://example.com/return",
-          },
-          card.id
-        )
-      ).rejects.toThrow();
-      await expect(
-        gr4vy.paymentMethods.paymentServiceTokens.delete(
-          card.id,
-          "00000000-0000-0000-0000-000000000000"
-        )
-      ).rejects.toThrow();
+      await reaches(
+        () =>
+          gr4vy.paymentMethods.paymentServiceTokens.create(
+            {
+              paymentServiceId: "00000000-0000-0000-0000-000000000000",
+              redirectUrl: "https://example.com/return",
+            },
+            card.id
+          ),
+        "paymentMethods.paymentServiceTokens.create"
+      );
+      await reaches(
+        () =>
+          gr4vy.paymentMethods.paymentServiceTokens.delete(
+            card.id,
+            "00000000-0000-0000-0000-000000000000"
+          ),
+        "paymentMethods.paymentServiceTokens.delete"
+      );
     });
   });
 });

--- a/tests/processing/transactions.test.ts
+++ b/tests/processing/transactions.test.ts
@@ -140,9 +140,10 @@ describe("Transaction refund settlements", () => {
   test("fetching a missing refund settlement is exercised at the request level", async () => {
     const created = await authorizeViaCheckoutSession(gr4vy, 1299);
 
-    await expect(
-      gr4vy.transactions.refundSettlements.get(created.id, MISSING_ID)
-    ).rejects.toThrow();
+    await reaches(
+      () => gr4vy.transactions.refundSettlements.get(created.id, MISSING_ID),
+      "transactions.refundSettlements.get"
+    );
   });
 });
 

--- a/tests/utils/reach.ts
+++ b/tests/utils/reach.ts
@@ -39,3 +39,44 @@ export const reaches = async (
     );
   }
 };
+
+/**
+ * Assert that an operation reached the server and the server *rejected* it with
+ * a client error (4xx).
+ *
+ * Use this where the rejection is the behaviour under test rather than an
+ * accepted side effect — "after delete, reading it back must 404", "this
+ * payload must be refused". Unlike {@link reaches}, a **2xx fails**: if a
+ * deleted resource is still readable, that is exactly the bug the test exists
+ * to catch, and it must not pass.
+ *
+ * Like {@link reaches}, this also fails on a 5xx and on any failure that never
+ * hit the wire — the gap in a plain `rejects.toThrow()`, which passes on a
+ * local serialization error and so can go green without the API ever being
+ * asked.
+ */
+export const rejectsClientError = async (
+  action: () => Promise<unknown>,
+  description: string
+): Promise<void> => {
+  try {
+    await action();
+  } catch (error) {
+    if (error instanceof Gr4vyError) {
+      const { statusCode } = error;
+      if (statusCode >= 400 && statusCode < 500) {
+        return; // reached + cleanly rejected, as expected
+      }
+      throw new Error(
+        `[reject] ${description}: expected a 4xx, got ${statusCode}: ${error.message}`
+      );
+    }
+    throw new Error(
+      `[reject] ${description}: the call failed before reaching the server: ` +
+        `${(error as Error)?.name} — ${(error as Error)?.message}`
+    );
+  }
+  throw new Error(
+    `[reject] ${description}: expected the API to reject this, but it succeeded.`
+  );
+};


### PR DESCRIPTION
Follow-up to #332, which flagged this while adding the three missing endpoint tests.

## The problem

Endpoint reach is measured from **HTTP requests actually sent**. A request-level test is therefore only worth something if a well-formed request left the process — and `rejects.toThrow()` cannot tell these two apart:

- the request went out and the API rejected it (a 4xx) — what we want
- the SDK threw locally before sending anything — bad argument, serialization error

Both pass. So a test can sit green next to a coverage report that says the endpoint was never reached, with nothing pointing at why. It also means someone can later break the arguments, the SDK starts failing locally, the test stays green, and reach silently drops.

## What changed

`tests/utils/reach.ts` now exports two assertions, and all 40 call sites use the appropriate one:

| Helper | Use when | 2xx | 4xx | 5xx | Never reached the wire |
| --- | --- | --- | --- | --- | --- |
| `reaches` | The op can't reach a happy path here; you only need it reached | pass | pass | **fail** | **fail** |
| `rejectsClientError` | The rejection *is* the assertion | **fail** | pass | **fail** | **fail** |

**This is deliberately not a blanket swap.** Six sites are `after delete → get must fail`:

- `payment-methods.test.ts`, `buyers.test.ts`, `digital-wallets.test.ts`, `checkout-sessions.test.ts`, `payment-services.test.ts`, `flows/buyer-lifecycle.test.ts`

Converting those to `reaches` would have **weakened** them, because `reaches` passes on a 2xx — and a deleted resource still being readable is precisely the bug they exist to catch. They use `rejectsClientError`, which demands a 4xx, so they end up stricter than before.

The other 34 are genuine reach probes and use `reaches`.

One assertion is left alone: `checkout-sessions.test.ts` asserts the specific `"Request failed validation"` message, where the message *is* the point.

`TESTING.md` documents the split so the next person picks the right one.

## Verification

`tsc --noEmit` and `eslint --max-warnings=0` are clean; all 86 tests still register with vitest (unchanged from `main`), so nothing was dropped in the rewrite. As with #332 I have no sandbox signing key locally, so CI is the behavioural check — I'd expect `coverage` to stay at **119 / 119**, since this changes how outcomes are asserted, not which requests go out.

Note: the diff is functional only. I deliberately did not run Prettier — it isn't a dependency of this repo and there's no config, so it reformats unrelated lines (it wanted trailing commas throughout). Everything here is hand-matched to the surrounding style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)